### PR TITLE
Livid Instruments DS1: Channel send and pan configuration

### DIFF
--- a/Livid Python Scripts/Livid_DS1_v2/DS1.py
+++ b/Livid Python Scripts/Livid_DS1_v2/DS1.py
@@ -222,12 +222,12 @@ class DS1(LividControlSurface):
 		self._mixer.set_prehear_volume_control(self._side_dial[3])
 		self._mixer.layer = Layer(volume_controls = self._fader_matrix, track_select_dial = self._encoder[1])
 		self._strip = [self._mixer.channel_strip(index) for index in range(8)]
-		if KNOBS_ARE_SENDS:
+		if PAN_KNOB:
 			for index in range(8):
-				self._strip[index].layer = Layer(priority = 4, send_controls = self._dial_matrix.submatrix[index:index+1, :4], pan_control = self._dial[4][index])
+				self._strip[index].layer = Layer(priority = 4, send_controls = self._dial_matrix.submatrix[index:index+1, :SEND_KNOBS], parameter_controls = self._dial_matrix.submatrix[index:index+1, SEND_KNOBS:4], pan_control = self._dial[4][index])
 		else:
 			for index in range(8):
-				self._strip[index].layer = Layer(priority = 4, parameter_controls = self._dial_matrix.submatrix[index:index+1, :])
+				self._strip[index].layer = Layer(priority = 4, send_controls = self._dial_matrix.submatrix[index:index+1, :SEND_KNOBS], parameter_controls = self._dial_matrix.submatrix[index:index+1, SEND_KNOBS:])
 		self._mixer.selected_strip().layer = Layer(priority = 4, parameter_controls = self._selected_parameter_controls)
 		self._mixer.master_strip().layer = Layer(priority = 4, parameter_controls = self._side_dial_matrix.submatrix[:3, :])
 		self._mixer.main_layer = AddLayerMode(self._mixer, Layer(priority = 4, solo_buttons = self._bottom_buttons, mute_buttons = self._top_buttons))

--- a/Livid Python Scripts/Livid_DS1_v2/Map.py
+++ b/Livid Python Scripts/Livid_DS1_v2/Map.py
@@ -34,7 +34,8 @@ DS1_ENCODER_BUTTONS = [25, 26, 27, 28]
 
 DS1_SIDE_DIALS = [50, 51, 52, 53]
 
-KNOBS_ARE_SENDS = False
+SEND_KNOBS = 0 # Knobs mapped to sends (remaining mapped to track parameters or pan)
+PAN_KNOB = False # Knob 5 mapped to Pan
 
 
 class DS1Colors:


### PR DESCRIPTION
Add Livid instruments DS1 V2 control script configuration:
- `PAN_KNOB` Boolean to enable/disable mapping of the fifth/bottom knob to channel pan control
- `SEND_KNOBS` Integer to set the number of knobs to map to sends (from the top)

I don't know what your policy is on PRs but I made the changes for my personal setup so thought I would share.